### PR TITLE
fix: remove all remaining uses of the term NixOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ All applications are defined in [`src/lib/data.ts`](src/lib/data.ts).
     arch: 'package-name',           // Use AUR package names with -bin suffix
     fedora: 'package-name',
     opensuse: 'package-name',
-    nixos: 'package-name',
+    nix: 'package-name',
     flatpak: 'com.vendor.AppId',    // Full Flatpak ID
     snap: 'snap-name',              // Include --classic if needed
   },
@@ -218,7 +218,7 @@ Open a [Discussion](https://github.com/abusoww/tuxmate/discussions) or create an
     arch: 'package-name',           // Use AUR package names with -bin suffix
     fedora: 'package-name',
     opensuse: 'package-name',
-    nixos: 'package-name',
+    nix: 'package-name',
     flatpak: 'com.vendor.AppId',    // Full Flatpak ID
     snap: 'snap-name',              // Include --classic if needed
   },

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ a new machine or can't remember all the package names for your favorite apps?
 - Arch Linux (pacman + AUR via yay)
 - Fedora (dnf)
 - openSUSE (zypper)
-- NixOS (nix-env)
+- Nix (nix-env)
 - Flatpak
 - Snap
 
@@ -107,8 +107,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 ## 🎯 Roadmap
 
 ### Completed
-- [x] Multi-distro support (Ubuntu, Debian, Arch, Fedora, openSUSE, NixOS)
-- [x] Flatpak & Snap universal package support
+- [x] Multi-distro support (Ubuntu, Debian, Arch, Fedora, openSUSE)
+- [x] Nix, Flatpak & Snap universal package support
 - [x] 150+ applications across 15 categories
 - [x] Smart script generation with error handling
 - [x] AUR helper integration (yay) for Arch

--- a/src/hooks/useLinuxInit.ts
+++ b/src/hooks/useLinuxInit.ts
@@ -195,9 +195,9 @@ export function useLinuxInit(): UseLinuxInitReturn {
 
         if (packageNames.length === 0) return '# No packages selected';
 
-        // Handle special cases for NixOS and Snap
+        // Handle special cases for Nix and Snap
         if (selectedDistro === 'nix') {
-            // NixOS needs nixpkgs. prefix for each package
+            // Nix needs nixpkgs. prefix for each package
             return `${distro.installPrefix} ${packageNames.map(p => `nixpkgs.${p}`).join(' ')}`;
         }
 

--- a/src/lib/generateInstallScript.ts
+++ b/src/lib/generateInstallScript.ts
@@ -542,11 +542,11 @@ print_summary
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-//  NIXOS SCRIPT
+//  NIX SCRIPT
 // ═══════════════════════════════════════════════════════════════════════════════
 
-function generateNixOSScript(packages: { app: AppData; pkg: string }[]): string {
-    return generateAsciiHeader('NixOS', packages.length) + generateSharedUtils(packages.length) + `
+function generateNixScript(packages: { app: AppData; pkg: string }[]): string {
+    return generateAsciiHeader('Nix', packages.length) + generateSharedUtils(packages.length) + `
 is_installed() { nix-env -q 2>/dev/null | grep -q "$1"; }
 
 install_pkg() {
@@ -796,7 +796,7 @@ export function generateInstallScript(options: ScriptOptions): string {
         case 'arch': return generateArchScript(packages);
         case 'fedora': return generateFedoraScript(packages);
         case 'opensuse': return generateOpenSUSEScript(packages);
-        case 'nix': return generateNixOSScript(packages);
+        case 'nix': return generateNixScript(packages);
         case 'flatpak': return generateFlatpakScript(packages);
         case 'snap': return generateSnapScript(packages);
         default: return '#!/bin/bash\necho "Unsupported distribution"\nexit 1';


### PR DESCRIPTION
The goal is to remove the possible ambiguity with the mixed use of both "nix" and "NixOS", in favor of the first.

Of particular importance is the change in the README to make it clear that Nix is not so much a distribution as it is an universal package distribution option on par with Flatpak and Snap.