### PR TITLE
feat(ui): add white squircle backgrounds to app icons

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -450,7 +450,11 @@ function DistroSelector({ selectedDistro, onSelect }: { selectedDistro: DistroId
 function AppIcon({ url, name }: { url: string; name: string }) {
     const [error, setError] = useState(false);
     if (error) return <div className="w-4 h-4 rounded bg-[var(--accent)] flex items-center justify-center text-[10px] font-bold">{name[0]}</div>;
-    return <img src={url} alt="" aria-hidden="true" width={16} height={16} className="w-4 h-4 object-contain opacity-75" onError={() => setError(true)} loading="lazy" />;
+    return (
+        <div className="w-4 h-4 rounded-[6px] bg-white dark:bg-white flex items-center justify-center p-0.5 shrink-0">
+            <img src={url} alt="" aria-hidden="true" width={16} height={16} className="w-full h-full object-contain" onError={() => setError(true)} loading="lazy" />
+        </div>
+    );
 }
 
 // App Item


### PR DESCRIPTION
Improves app icon visibility and consistency by adding white rounded square backgrounds.

## Changes

- Added white squircle (rounded square) backgrounds to all app icons
- Uses `rounded-[6px]` for smooth squircle effect
- White background in both light and dark modes
- Small padding for breathing room around icons

## Benefits

- Better icon visibility, especially in dark mode
- Consistent visual appearance across all icons
- Improved contrast against dark backgrounds

Improvements for [#3](https://github.com/abusoww/tuxmate/issues/3)

---

<img width="1920" height="1080" alt="Instantaneu din 2025-12-28 14-53-26" src="https://github.com/user-attachments/assets/69b44146-dbed-4978-af02-88effc382615" />
