### PR TITLE
nyxt: add to browsers

### DIFF
--- a/src/lib/apps/web-browsers.json
+++ b/src/lib/apps/web-browsers.json
@@ -208,7 +208,7 @@
       "nix": "nyxt",
       "opensuse": "nyxt"
     },
-    "unavailableReason": "Not in most official repos. Use [Flatpak](https://flathub.org/en/apps/engineer.atlas.Nyxt).",
+    "unavailableReason": "Not in most official repos. Use [Flatpak](https://flathub.org/en/apps/engineer.atlas.Nyxt) or see [nyxt-browser.com](https://nyxt-browser.com/download)",
     "icon": {
       "type": "url",
       "url": "https://nyxt.atlas.engineer/image/nyxt_square_corner_128x128.png"


### PR DESCRIPTION
## Summary
Added Nyxt to the list of browsers.

## Changes
| App Name | Category | Sources |
|----------|----------|---------|
| Nyxt | Web Browsers | flatpak, nix, pacman, zypper |

## Verification
> Package names verified against official sources.

| Source | Link |
|--------|------|
| Repology | [Link](https://repology.org/project/nyxt/versions) |
| Arch | [Link](https://archlinux.org/packages/extra/x86_64/nyxt/) |
| Flatpak | [Link](https://flathub.org/en/apps/engineer.atlas.Nyxt) |
| Nix | [Link](https://search.nixos.org/packages?channel=25.11&query=nyxt&show=nyxt) |
| OpenSUSE | [Link](https://build.opensuse.org/package/show/openSUSE:Factory/nyxt) |

## Testing
- [x] `npm run dev` working
- [x] `npm run build` passed

## Screenshots (if applicable)


<!-- Add screenshots for UI changes -->
