### PR TITLE
feat: enable selecting flatpak packages on any distro when Flatpak is toggled on

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import { categories, getAppsByCategory } from '@/lib/data';
 
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { HowItWorks, GitHubLink, ContributeLink } from '@/components/header';
-import { DistroSelector } from '@/components/distro';
+import { DistroSelector, FlatpakToggle } from '@/components/distro';
 import { CategorySection } from '@/components/app';
 import { CommandFooter } from '@/components/command';
 import { Tooltip, GlobalStyles, LoadingSkeleton } from '@/components/common';
@@ -39,6 +39,9 @@ export default function Home() {
         setSelectedHelper,
         hasUnfreePackages,
         unfreeAppNames,
+        isFlatpakEnabled,
+        toggleFlatpakEnabled,
+        isFlatpakFallback,
     } = useLinuxInit();
 
     const [searchQuery, setSearchQuery] = useState('');
@@ -308,6 +311,7 @@ export default function Home() {
                             <div className="flex items-center gap-2 pl-2 sm:pl-3 border-l border-[var(--border-primary)]">
                                 <ThemeToggle />
                                 <DistroSelector selectedDistro={selectedDistro} onSelect={setSelectedDistro} />
+                                <FlatpakToggle enabled={isFlatpakEnabled} onToggle={toggleFlatpakEnabled} selectedDistro={selectedDistro} />
                             </div>
                         </div>
                     </div>
@@ -347,6 +351,7 @@ export default function Home() {
                                             onAppFocus={(appId) => setFocusByItem('app', appId)}
                                             isVerified={isVerified}
                                             getVerificationSource={getVerificationSource}
+                                            isFlatpakFallback={isFlatpakFallback}
                                         />
                                     ))}
                                 </div>
@@ -385,6 +390,7 @@ export default function Home() {
                                             onAppFocus={(appId) => setFocusByItem('app', appId)}
                                             isVerified={isVerified}
                                             getVerificationSource={getVerificationSource}
+                                            isFlatpakFallback={isFlatpakFallback}
                                         />
                                     ))}
                                 </div>
@@ -416,6 +422,7 @@ export default function Home() {
                 onDrawerOpen={() => setDrawerOpen(true)}
                 onDrawerClose={closeDrawer}
                 activeShortcut={activeShortcut}
+                isFlatpakEnabled={isFlatpakEnabled}
             />
         </div>
     );

--- a/src/components/app/AppItem.tsx
+++ b/src/components/app/AppItem.tsx
@@ -36,6 +36,7 @@ interface AppItemProps {
     color?: string;
     isVerified?: boolean;
     verificationSource?: 'flathub' | 'snap' | null;
+    isFlatpakFallback?: boolean;
 }
 
 export const AppItem = memo(function AppItem({
@@ -51,6 +52,7 @@ export const AppItem = memo(function AppItem({
     color = 'gray',
     isVerified = false,
     verificationSource = null,
+    isFlatpakFallback = false,
 }: AppItemProps) {
     const getUnavailableText = () => {
         const distroName = distros.find(d => d.id === selectedDistro)?.name || '';
@@ -59,7 +61,7 @@ export const AppItem = memo(function AppItem({
 
     const isAur = selectedDistro === 'arch' && app.targets?.arch && isAurPackage(app.targets.arch);
     const hexColor = COLOR_MAP[color] || COLOR_MAP['gray'];
-    const checkboxColor = isAur ? '#1793d1' : hexColor;
+    const checkboxColor = isFlatpakFallback ? '#4A90D9' : isAur ? '#1793d1' : hexColor;
 
     return (
         <div
@@ -141,6 +143,17 @@ export const AppItem = memo(function AppItem({
                         <title>{verificationSource === 'flathub' ? 'Verified on Flathub' : 'Verified publisher on Snap Store'}</title>
                         <path d="M23 12l-2.44-2.79.34-3.69-3.61-.82-1.89-3.2L12 2.96 8.6 1.5 6.71 4.69 3.1 5.5l.34 3.7L1 12l2.44 2.79-.34 3.7 3.61.82 1.89 3.2 3.4-1.47 3.4 1.46 1.89-3.19 3.61-.82-.34-3.69L23 12m-12.91 4.72l-3.8-3.81 1.48-1.48 2.32 2.33 5.85-5.87 1.48 1.48-7.33 7.35z" />
                     </svg>
+                )}
+                {isFlatpakFallback && (
+                    <span
+                        className="ml-1.5 inline-flex items-center gap-0.5 px-1.5 py-0 text-[9px] font-semibold uppercase tracking-wider rounded-sm flex-shrink-0"
+                        style={{
+                            color: '#4A90D9',
+                            backgroundColor: 'color-mix(in srgb, #4A90D9, transparent 88%)',
+                        }}
+                    >
+                        flatpak
+                    </span>
                 )}
             </div>
             {!isAvailable && (

--- a/src/components/app/CategorySection.tsx
+++ b/src/components/app/CategorySection.tsx
@@ -26,6 +26,7 @@ interface CategorySectionProps {
     onAppFocus?: (appId: string) => void;
     isVerified?: (distro: DistroId, packageName: string) => boolean;
     getVerificationSource?: (distro: DistroId, packageName: string) => 'flathub' | 'snap' | null;
+    isFlatpakFallback?: (appId: string) => boolean;
 }
 
 const categoryColors: Record<Category, string> = {
@@ -64,6 +65,7 @@ function CategorySectionComponent({
     onAppFocus,
     isVerified,
     getVerificationSource,
+    isFlatpakFallback,
 }: CategorySectionProps) {
     const selectedInCategory = categoryApps.filter(a => selectedApps.has(a.id)).length;
     const isCategoryFocused = focusedType === 'category' && focusedId === category;
@@ -158,6 +160,7 @@ function CategorySectionComponent({
                                 ? getVerificationSource?.(selectedDistro, app.targets?.[selectedDistro] || '') || null
                                 : null
                         }
+                        isFlatpakFallback={isFlatpakFallback?.(app.id) || false}
                     />
                 ))}
             </div>
@@ -181,6 +184,7 @@ export const CategorySection = memo(CategorySectionComponent, (prevProps, nextPr
 
     if (prevProps.isVerified !== nextProps.isVerified) return false;
     if (prevProps.getVerificationSource !== nextProps.getVerificationSource) return false;
+    if (prevProps.isFlatpakFallback !== nextProps.isFlatpakFallback) return false;
 
     for (const app of nextProps.categoryApps) {
         if (prevProps.selectedApps.has(app.id) !== nextProps.selectedApps.has(app.id)) {

--- a/src/components/command/CommandFooter.tsx
+++ b/src/components/command/CommandFooter.tsx
@@ -32,6 +32,7 @@ interface CommandFooterProps {
     onDrawerOpen?: () => void;
     onDrawerClose?: () => void;
     activeShortcut?: string | null;
+    isFlatpakEnabled?: boolean;
 }
 
 
@@ -57,6 +58,7 @@ export function CommandFooter({
     onDrawerOpen: externalOnDrawerOpen,
     onDrawerClose: externalOnDrawerClose,
     activeShortcut,
+    isFlatpakEnabled,
 }: CommandFooterProps) {
     const [copied, setCopied] = useState(false);
     const [internalDrawerOpen, setInternalDrawerOpen] = useState(false);
@@ -115,6 +117,7 @@ export function CommandFooter({
             distroId: selectedDistro,
             selectedAppIds: selectedApps,
             helper: selectedHelper,
+            isFlatpakEnabled,
         });
         const isNix = selectedDistro === 'nix';
         const mimeType = isNix ? 'text/plain' : 'text/x-shellscript';

--- a/src/components/distro/FlatpakToggle.tsx
+++ b/src/components/distro/FlatpakToggle.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { memo } from 'react';
+import type { DistroId } from '@/lib/data';
+
+interface FlatpakToggleProps {
+    enabled: boolean;
+    onToggle: () => void;
+    selectedDistro: DistroId;
+}
+
+const FLATPAK_DISTROS: DistroId[] = ['ubuntu', 'debian', 'arch', 'fedora', 'opensuse'];
+
+function FlatpakToggleComponent({ enabled, onToggle, selectedDistro }: FlatpakToggleProps) {
+    if (!FLATPAK_DISTROS.includes(selectedDistro)) return null;
+
+    return (
+        <button
+            onClick={onToggle}
+            className="flex items-center gap-2 px-3 py-1.5 text-xs rounded-md border transition-all duration-150"
+            style={{
+                borderColor: enabled ? '#4A90D9' : 'var(--border-primary)',
+                backgroundColor: enabled ? 'color-mix(in srgb, #4A90D9, transparent 90%)' : 'transparent',
+                color: enabled ? '#4A90D9' : 'var(--text-muted)',
+            }}
+            title="Include Flatpak packages for apps not available in your distro's repos"
+        >
+            <svg className="w-3.5 h-3.5 flex-shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2L2 7v10l10 5 10-5V7L12 2zm0 2.18l7.5 3.75v7.14L12 18.82l-7.5-3.75V7.93L12 4.18z" />
+            </svg>
+            <span className="whitespace-nowrap font-medium">
+                {enabled ? 'Flatpak fallback on' : 'Flatpak fallback'}
+            </span>
+            <div
+                className="w-7 h-4 rounded-full relative transition-colors duration-150"
+                style={{ backgroundColor: enabled ? '#4A90D9' : 'var(--border-secondary)' }}
+            >
+                <div
+                    className="absolute top-0.5 w-3 h-3 rounded-full bg-white transition-transform duration-150"
+                    style={{ transform: enabled ? 'translateX(14px)' : 'translateX(2px)' }}
+                />
+            </div>
+        </button>
+    );
+}
+
+export const FlatpakToggle = memo(FlatpakToggleComponent);

--- a/src/components/distro/index.ts
+++ b/src/components/distro/index.ts
@@ -2,3 +2,4 @@
 
 export { DistroIcon } from './DistroIcon';
 export { DistroSelector } from './DistroSelector';
+export { FlatpakToggle } from './FlatpakToggle';

--- a/src/hooks/useLinuxInit.ts
+++ b/src/hooks/useLinuxInit.ts
@@ -6,6 +6,9 @@ import { isAurPackage } from '@/lib/aur';
 import { isUnfreePackage } from '@/lib/nixUnfree';
 
 export { isAurPackage, AUR_PATTERNS, KNOWN_AUR_PACKAGES } from '@/lib/aur';
+
+const FLATPAK_ELIGIBLE_DISTROS: DistroId[] = ['ubuntu', 'debian', 'arch', 'fedora', 'opensuse'];
+
 export interface UseLinuxInitReturn {
     selectedDistro: DistroId;
     selectedApps: Set<string>;
@@ -28,18 +31,23 @@ export interface UseLinuxInitReturn {
     hasUnfreePackages: boolean;
     unfreeAppNames: string[];
     isHydrated: boolean;
+    isFlatpakEnabled: boolean;
+    toggleFlatpakEnabled: () => void;
+    isFlatpakFallback: (appId: string) => boolean;
 }
 
 const STORAGE_KEY_DISTRO = 'linuxinit_distro';
 const STORAGE_KEY_APPS = 'linuxinit_apps';
 const STORAGE_KEY_YAY = 'linuxinit_yay_installed';
 const STORAGE_KEY_HELPER = 'linuxinit_selected_helper';
+const STORAGE_KEY_FLATPAK = 'linuxinit_flatpak_enabled';
 
 export function useLinuxInit(): UseLinuxInitReturn {
     const [selectedDistro, setSelectedDistroState] = useState<DistroId>('ubuntu');
     const [selectedApps, setSelectedApps] = useState<Set<string>>(new Set());
     const [hasYayInstalled, setHasYayInstalled] = useState(false);
     const [selectedHelper, setSelectedHelper] = useState<'yay' | 'paru'>('yay');
+    const [isFlatpakEnabled, setIsFlatpakEnabled] = useState(false);
     const [hydrated, setHydrated] = useState(false);
 
     useEffect(() => {
@@ -72,6 +80,11 @@ export function useLinuxInit(): UseLinuxInitReturn {
             if (savedHelper === 'paru') {
                 setSelectedHelper('paru');
             }
+
+            const savedFlatpak = localStorage.getItem(STORAGE_KEY_FLATPAK);
+            if (savedFlatpak === 'true') {
+                setIsFlatpakEnabled(true);
+            }
         } catch {
         }
         setHydrated(true);
@@ -84,9 +97,10 @@ export function useLinuxInit(): UseLinuxInitReturn {
             localStorage.setItem(STORAGE_KEY_APPS, JSON.stringify([...selectedApps]));
             localStorage.setItem(STORAGE_KEY_YAY, hasYayInstalled.toString());
             localStorage.setItem(STORAGE_KEY_HELPER, selectedHelper);
+            localStorage.setItem(STORAGE_KEY_FLATPAK, isFlatpakEnabled.toString());
         } catch {
         }
-    }, [selectedDistro, selectedApps, hasYayInstalled, selectedHelper, hydrated]);
+    }, [selectedDistro, selectedApps, hasYayInstalled, selectedHelper, isFlatpakEnabled, hydrated]);
 
     const aurPackageInfo = useMemo(() => {
         if (selectedDistro !== 'arch') {
@@ -128,12 +142,27 @@ export function useLinuxInit(): UseLinuxInitReturn {
         return { hasUnfree: unfreeAppNames.length > 0, appNames: unfreeAppNames };
     }, [selectedDistro, selectedApps]);
 
+    const flatpakActive = isFlatpakEnabled && FLATPAK_ELIGIBLE_DISTROS.includes(selectedDistro);
+
+    const isFlatpakFallback = useCallback((appId: string): boolean => {
+        if (!flatpakActive) return false;
+        const app = apps.find(a => a.id === appId);
+        if (!app) return false;
+        const nativePkg = app.targets[selectedDistro];
+        if (nativePkg !== undefined && nativePkg !== null) return false;
+        return app.targets['flatpak'] !== undefined && app.targets['flatpak'] !== null;
+    }, [flatpakActive, selectedDistro]);
+
     const isAppAvailable = useCallback((appId: string): boolean => {
         const app = apps.find(a => a.id === appId);
         if (!app) return false;
         const packageName = app.targets[selectedDistro];
-        return packageName !== undefined && packageName !== null;
-    }, [selectedDistro]);
+        if (packageName !== undefined && packageName !== null) return true;
+        if (flatpakActive) {
+            return app.targets['flatpak'] !== undefined && app.targets['flatpak'] !== null;
+        }
+        return false;
+    }, [selectedDistro, flatpakActive]);
 
     const getPackageName = useCallback((appId: string): string | null => {
         const app = apps.find(a => a.id === appId);
@@ -145,24 +174,28 @@ export function useLinuxInit(): UseLinuxInitReturn {
         setSelectedDistroState(distroId);
         setSelectedApps(prevSelected => {
             const newSelected = new Set<string>();
+            const flatpakOk = isFlatpakEnabled && FLATPAK_ELIGIBLE_DISTROS.includes(distroId);
             prevSelected.forEach(appId => {
                 const app = apps.find(a => a.id === appId);
                 if (app) {
                     const packageName = app.targets[distroId];
                     if (packageName !== undefined && packageName !== null) {
                         newSelected.add(appId);
+                    } else if (flatpakOk && app.targets['flatpak'] !== undefined && app.targets['flatpak'] !== null) {
+                        newSelected.add(appId);
                     }
                 }
             });
             return newSelected;
         });
-    }, []);
+    }, [isFlatpakEnabled]);
 
     const toggleApp = useCallback((appId: string) => {
         const app = apps.find(a => a.id === appId);
         if (!app) return;
         const pkg = app.targets[selectedDistro];
-        if (pkg === undefined || pkg === null) return;
+        const hasFlatpakFallback = flatpakActive && app.targets['flatpak'] !== undefined && app.targets['flatpak'] !== null;
+        if ((pkg === undefined || pkg === null) && !hasFlatpakFallback) return;
 
         setSelectedApps(prev => {
             const newSet = new Set(prev);
@@ -173,17 +206,21 @@ export function useLinuxInit(): UseLinuxInitReturn {
             }
             return newSet;
         });
-    }, [selectedDistro]);
+    }, [selectedDistro, flatpakActive]);
 
     const selectAll = useCallback(() => {
         const allAvailable = apps
             .filter(app => {
                 const pkg = app.targets[selectedDistro];
-                return pkg !== undefined && pkg !== null;
+                if (pkg !== undefined && pkg !== null) return true;
+                if (flatpakActive) {
+                    return app.targets['flatpak'] !== undefined && app.targets['flatpak'] !== null;
+                }
+                return false;
             })
             .map(app => app.id);
         setSelectedApps(new Set(allAvailable));
-    }, [selectedDistro]);
+    }, [selectedDistro, flatpakActive]);
 
     const clearAll = useCallback(() => {
         setSelectedApps(new Set());
@@ -192,9 +229,13 @@ export function useLinuxInit(): UseLinuxInitReturn {
     const availableCount = useMemo(() => {
         return apps.filter(app => {
             const pkg = app.targets[selectedDistro];
-            return pkg !== undefined && pkg !== null;
+            if (pkg !== undefined && pkg !== null) return true;
+            if (flatpakActive) {
+                return app.targets['flatpak'] !== undefined && app.targets['flatpak'] !== null;
+            }
+            return false;
         }).length;
-    }, [selectedDistro]);
+    }, [selectedDistro, flatpakActive]);
 
     const generatedCommand = useMemo(() => {
         if (selectedApps.size === 0) {
@@ -204,59 +245,68 @@ export function useLinuxInit(): UseLinuxInitReturn {
         const distro = distros.find(d => d.id === selectedDistro);
         if (!distro) return '';
 
-        const packageNames: string[] = [];
+        const nativePackages: string[] = [];
+        const flatpakFallbackPackages: string[] = [];
+
         selectedApps.forEach(appId => {
             const app = apps.find(a => a.id === appId);
             if (app) {
                 const pkg = app.targets[selectedDistro];
-                if (pkg) packageNames.push(pkg);
+                if (pkg) {
+                    nativePackages.push(pkg);
+                } else if (flatpakActive && app.targets['flatpak']) {
+                    flatpakFallbackPackages.push(app.targets['flatpak']);
+                }
             }
         });
 
-        if (packageNames.length === 0) return '# No packages selected';
+        if (nativePackages.length === 0 && flatpakFallbackPackages.length === 0) return '# No packages selected';
 
-        if (selectedDistro === 'nix') {
-            const sortedPkgs = packageNames.filter(p => p.trim()).sort();
-            const pkgList = sortedPkgs.map(p => `    ${p}`).join('\n');
-            return `environment.systemPackages = with pkgs; [\n${pkgList}\n];`;
-        }
+        let cmd = '';
 
-        if (selectedDistro === 'snap') {
-            if (packageNames.length === 1) {
-                return `${distro.installPrefix} ${packageNames[0]}`;
-            }
-            return packageNames.map(p => `sudo snap install ${p}`).join(' && ');
-        }
-
-        if (selectedDistro === 'arch' && aurPackageInfo.hasAur) {
-            if (!hasYayInstalled) {
-                const helperName = selectedHelper; // yay or paru
-
-                const installHelperCmd = `sudo pacman -S --needed git base-devel && git clone https://aur.archlinux.org/${helperName}.git /tmp/${helperName} && cd /tmp/${helperName} && makepkg -si --noconfirm && cd - && rm -rf /tmp/${helperName}`;
-
-                const installCmd = `${helperName} -S --needed --noconfirm ${packageNames.join(' ')}`;
-
-                return `${installHelperCmd} && ${installCmd}`;
+        if (nativePackages.length > 0) {
+            if (selectedDistro === 'nix') {
+                const sortedPkgs = nativePackages.filter(p => p.trim()).sort();
+                const pkgList = sortedPkgs.map(p => `    ${p}`).join('\n');
+                cmd = `environment.systemPackages = with pkgs; [\n${pkgList}\n];`;
+            } else if (selectedDistro === 'snap') {
+                if (nativePackages.length === 1) {
+                    cmd = `${distro.installPrefix} ${nativePackages[0]}`;
+                } else {
+                    cmd = nativePackages.map(p => `sudo snap install ${p}`).join(' && ');
+                }
+            } else if (selectedDistro === 'arch' && aurPackageInfo.hasAur) {
+                if (!hasYayInstalled) {
+                    const helperName = selectedHelper;
+                    const installHelperCmd = `sudo pacman -S --needed git base-devel && git clone https://aur.archlinux.org/${helperName}.git /tmp/${helperName} && cd /tmp/${helperName} && makepkg -si --noconfirm && cd - && rm -rf /tmp/${helperName}`;
+                    const installCmd = `${helperName} -S --needed --noconfirm ${nativePackages.join(' ')}`;
+                    cmd = `${installHelperCmd} && ${installCmd}`;
+                } else {
+                    cmd = `${selectedHelper} -S --needed --noconfirm ${nativePackages.join(' ')}`;
+                }
+            } else if (selectedDistro === 'homebrew') {
+                const formulae = nativePackages.filter(p => !p.startsWith('--cask '));
+                const casks = nativePackages.filter(p => p.startsWith('--cask ')).map(p => p.replace('--cask ', ''));
+                const parts: string[] = [];
+                if (formulae.length > 0) parts.push(`brew install ${formulae.join(' ')}`);
+                if (casks.length > 0) parts.push(`brew install --cask ${casks.join(' ')}`);
+                cmd = parts.join(' && ') || '';
             } else {
-                return `${selectedHelper} -S --needed --noconfirm ${packageNames.join(' ')}`;
+                cmd = `${distro.installPrefix} ${nativePackages.join(' ')}`;
             }
         }
 
-        if (selectedDistro === 'homebrew') {
-            const formulae = packageNames.filter(p => !p.startsWith('--cask '));
-            const casks = packageNames.filter(p => p.startsWith('--cask ')).map(p => p.replace('--cask ', ''));
-            const parts: string[] = [];
-            if (formulae.length > 0) {
-                parts.push(`brew install ${formulae.join(' ')}`);
-            }
-            if (casks.length > 0) {
-                parts.push(`brew install --cask ${casks.join(' ')}`);
-            }
-            return parts.join(' && ') || '# No packages selected';
+        if (flatpakFallbackPackages.length > 0) {
+            const flatpakCmd = `flatpak install flathub -y ${flatpakFallbackPackages.join(' ')}`;
+            cmd = cmd ? `${cmd} && ${flatpakCmd}` : flatpakCmd;
         }
 
-        return `${distro.installPrefix} ${packageNames.join(' ')}`;
-    }, [selectedDistro, selectedApps, aurPackageInfo.hasAur, hasYayInstalled, selectedHelper]);
+        return cmd || '# No packages selected';
+    }, [selectedDistro, selectedApps, aurPackageInfo.hasAur, hasYayInstalled, selectedHelper, flatpakActive]);
+
+    const toggleFlatpakEnabled = useCallback(() => {
+        setIsFlatpakEnabled(prev => !prev);
+    }, []);
 
     return {
         selectedDistro,
@@ -280,6 +330,9 @@ export function useLinuxInit(): UseLinuxInitReturn {
         hasUnfreePackages: unfreePackageInfo.hasUnfree,
         unfreeAppNames: unfreePackageInfo.appNames,
         isHydrated: hydrated,
+        isFlatpakEnabled,
+        toggleFlatpakEnabled,
+        isFlatpakFallback,
     };
 }
 

--- a/src/lib/generateInstallScript.ts
+++ b/src/lib/generateInstallScript.ts
@@ -1,4 +1,4 @@
-import { distros, type DistroId } from './data';
+import { distros, apps, type DistroId } from './data';
 import {
     getSelectedPackages,
     generateUbuntuScript,
@@ -16,29 +16,67 @@ interface GenerateOptions {
     distroId: DistroId;
     selectedAppIds: Set<string>;
     helper?: 'yay' | 'paru';
+    isFlatpakEnabled?: boolean;
+}
+
+const FLATPAK_ELIGIBLE_DISTROS: DistroId[] = ['ubuntu', 'debian', 'arch', 'fedora', 'opensuse'];
+
+function getFlatpakFallbackPackages(selectedAppIds: Set<string>, distroId: DistroId) {
+    return Array.from(selectedAppIds)
+        .map(id => apps.find(a => a.id === id))
+        .filter(app => {
+            if (!app) return false;
+            if (app.targets[distroId]) return false;
+            return !!app.targets['flatpak'];
+        })
+        .map(app => ({ app: app!, pkg: app!.targets['flatpak']! }));
 }
 
 export function generateInstallScript(options: GenerateOptions): string {
-    const { distroId, selectedAppIds, helper = 'yay' } = options;
+    const { distroId, selectedAppIds, helper = 'yay', isFlatpakEnabled = false } = options;
     const distro = distros.find(d => d.id === distroId);
 
     if (!distro) return '#!/bin/bash\necho "Error: Unknown distribution"\nexit 1';
 
     const packages = getSelectedPackages(selectedAppIds, distroId);
-    if (packages.length === 0) return '#!/bin/bash\necho "No packages selected"\nexit 0';
+    const flatpakFallbacks = (isFlatpakEnabled && FLATPAK_ELIGIBLE_DISTROS.includes(distroId))
+        ? getFlatpakFallbackPackages(selectedAppIds, distroId)
+        : [];
 
-    switch (distroId) {
-        case 'ubuntu': return generateUbuntuScript(packages);
-        case 'debian': return generateDebianScript(packages);
-        case 'arch': return generateArchScript(packages, helper);
-        case 'fedora': return generateFedoraScript(packages);
-        case 'opensuse': return generateOpenSUSEScript(packages);
-        case 'nix': return generateNixConfig(packages);
-        case 'flatpak': return generateFlatpakScript(packages);
-        case 'snap': return generateSnapScript(packages);
-        case 'homebrew': return generateHomebrewScript(packages);
-        default: return '#!/bin/bash\necho "Unsupported distribution"\nexit 1';
+    if (packages.length === 0 && flatpakFallbacks.length === 0) {
+        return '#!/bin/bash\necho "No packages selected"\nexit 0';
     }
+
+    let script = '';
+
+    if (packages.length > 0) {
+        switch (distroId) {
+            case 'ubuntu': script = generateUbuntuScript(packages); break;
+            case 'debian': script = generateDebianScript(packages); break;
+            case 'arch': script = generateArchScript(packages, helper); break;
+            case 'fedora': script = generateFedoraScript(packages); break;
+            case 'opensuse': script = generateOpenSUSEScript(packages); break;
+            case 'nix': script = generateNixConfig(packages); break;
+            case 'flatpak': script = generateFlatpakScript(packages); break;
+            case 'snap': script = generateSnapScript(packages); break;
+            case 'homebrew': script = generateHomebrewScript(packages); break;
+            default: script = '#!/bin/bash\necho "Unsupported distribution"\nexit 1'; break;
+        }
+    }
+
+    if (flatpakFallbacks.length > 0) {
+        const appendedSection = generateFlatpakScript(flatpakFallbacks, { isAppended: true, existingTotal: packages.length });
+        if (packages.length > 0) {
+            // Strip the final print_summary and restart message from the primary script,
+            // since the appended flatpak section will handle that.
+            script = script.replace(/\nprint_summary\n[^\n]*\n[^\n]*$/, '');
+            script += '\n' + appendedSection;
+        } else {
+            script = generateFlatpakScript(flatpakFallbacks);
+        }
+    }
+
+    return script;
 }
 
 export function generateCommandline(options: GenerateOptions): string {

--- a/src/lib/scripts/flatpak.ts
+++ b/src/lib/scripts/flatpak.ts
@@ -1,6 +1,17 @@
 import { generateAsciiHeader, generateSharedUtils, escapeShellString, type PackageInfo } from './shared';
 
-export function generateFlatpakScript(packages: PackageInfo[]): string {
+interface FlatpakScriptOptions {
+    isAppended?: boolean;
+    existingTotal?: number;
+}
+
+export function generateFlatpakScript(packages: PackageInfo[], options: FlatpakScriptOptions = {}): string {
+    const { isAppended = false, existingTotal = 0 } = options;
+
+    if (isAppended) {
+        return generateAppendedFlatpakSection(packages, existingTotal);
+    }
+
     return generateAsciiHeader('Flatpak', packages.length) + generateSharedUtils('flatpak', packages.length) + `
 is_installed() { flatpak list --app --columns=application 2>/dev/null | grep -Fxq "$1"; }
 
@@ -55,6 +66,70 @@ info "Installing $TOTAL packages"
 echo >&3
 
 ${packages.map(({ app, pkg }) => `install_pkg "${escapeShellString(app.name)}" "${pkg}"`).join('\n')}
+
+print_summary
+echo >&3
+info "Restart session for new apps to appear in menu." >&3
+`;
+}
+
+function generateAppendedFlatpakSection(packages: PackageInfo[], existingTotal: number): string {
+    const newTotal = existingTotal + packages.length;
+
+    return `
+# ---------------------------------------------------------------------------
+#  Flatpak fallback packages
+# ---------------------------------------------------------------------------
+
+TOTAL=${newTotal}
+
+flatpak_is_installed() { flatpak list --app --columns=application 2>/dev/null | grep -Fxq "$1"; }
+
+flatpak_install_pkg() {
+    local name=$1 appid=$2
+    CURRENT=$((CURRENT + 1))
+
+    if flatpak_is_installed "$appid"; then
+        skip "$name"
+        SKIPPED+=("$name")
+        return 0
+    fi
+
+    local start=$(date +%s)
+
+    with_retry flatpak install flathub -y "$appid" &
+    local pid=$!
+
+    if animate_progress "$name" $pid; then
+        local elapsed=$(($(date +%s) - start))
+        printf "\\r\\033[K" >&3
+        success "$name" "\${elapsed}s"
+        SUCCEEDED+=("$name")
+    else
+        printf "\\r\\033[K" >&3
+        error "$name"
+        FAILED+=("$name")
+    fi
+}
+
+command -v flatpak &>/dev/null || {
+    error "Flatpak not installed — skipping flatpak fallback packages"
+    info "Install flatpak first: sudo apt/dnf/pacman install flatpak"
+}
+
+if command -v flatpak &>/dev/null; then
+    if ! flatpak remotes 2>/dev/null | grep -q flathub; then
+        info "Adding Flathub..."
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo >/dev/null 2>&1
+        success "Flathub added"
+    fi
+
+    echo >&3
+    info "Installing ${packages.length} flatpak fallback packages"
+    echo >&3
+
+${packages.map(({ app, pkg }) => `    flatpak_install_pkg "${escapeShellString(app.name)}" "${pkg}"`).join('\n')}
+fi
 
 print_summary
 echo >&3


### PR DESCRIPTION
## Summary

Closes #46

When using a distro like Ubuntu, Fedora, or Arch, users can now toggle on **Flatpak fallback** to see and select apps that aren't available in the native repos but exist on Flathub. Selected flatpak fallback apps are installed alongside native packages — the generated command appends `flatpak install` after the distro's package manager, and the download script appends a dedicated flatpak section.

## What changed

- **New `FlatpakToggle` component** — appears next to the distro selector for eligible distros (Ubuntu, Debian, Arch, Fedora, OpenSUSE)
- **`useLinuxInit` hook** — added `isFlatpakEnabled` state, `toggleFlatpakEnabled`, and `isFlatpakFallback` helper. `isAppAvailable`, `toggleApp`, `selectAll`, and `availableCount` now account for flatpak fallbacks when the toggle is on. State is persisted to localStorage.
- **`AppItem`** — shows a "flatpak" badge on fallback apps with Flatpak-blue checkbox color
- **`CategorySection`** — passes `isFlatpakFallback` through to AppItem
- **`CommandFooter`** — passes `isFlatpakEnabled` to script generation
- **`generateInstallScript`** — when `isFlatpakEnabled` is set, collects flatpak fallback packages and either appends them to the primary distro script or generates a standalone flatpak script
- **`flatpak.ts`** — new `isAppended` mode that generates a flatpak section meant to be appended to another distro's script (namespaced functions to avoid conflicts, increments TOTAL, reuses shared utils from the primary script)

## How it works

1. User selects Ubuntu (or any eligible distro)
2. Toggles on "Flatpak fallback" in the header
3. Previously unavailable apps that have a Flatpak target now appear as selectable with a "flatpak" badge
4. The one-liner command gets `&& flatpak install flathub -y ...` appended
5. The download script gets an appended flatpak section after the native installs