### PR TITLE
add: a bunch of communication apps

### DIFF
--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -1,166 +1,187 @@
 [
-    {
-        "id": "discord",
-        "name": "Discord",
-        "description": "Popular voice, video, and text chat platform",
-        "category": "Communication",
-        "targets": {
-            "arch": "discord",
-            "opensuse": "discord",
-            "nix": "discord",
-            "flatpak": "com.discordapp.Discord",
-            "snap": "discord",
-            "homebrew": "--cask discord"
-        },
-        "unavailableReason": "Not in official repos. Install via [Flatpak](https://flathub.org/en/apps/com.discordapp.Discord) or download from [discord.com/download](https://discord.com/download).",
-        "icon": {
-            "type": "iconify",
-            "set": "simple-icons",
-            "name": "discord",
-            "color": "#5865F2"
-        }
+  {
+    "id": "discord",
+    "name": "Discord",
+    "description": "Popular voice, video, and text chat platform",
+    "category": "Communication",
+    "targets": {
+      "arch": "discord",
+      "opensuse": "discord",
+      "nix": "discord",
+      "flatpak": "com.discordapp.Discord",
+      "snap": "discord",
+      "homebrew": "--cask discord"
     },
-    {
-        "id": "vesktop",
-        "name": "Vesktop",
-        "description": "Discord client with Vencord mods built-in",
-        "category": "Communication",
-        "targets": {
-            "arch": "vesktop-bin",
-            "nix": "vesktop",
-            "flatpak": "dev.vencord.Vesktop",
-            "homebrew": "--cask vesktop"
-        },
-        "unavailableReason": "Not available in official repos. Check it on [Flatpak](https://flathub.org/en/apps/dev.vencord.Vesktop) or Download from [vesktop.dev/install/linux](https://vesktop.dev/install/linux/).",
-        "icon": {
-            "type": "url",
-            "url": "https://avatars.githubusercontent.com/u/113042587?s=200&v=4"
-        }
-    },
-    {
-        "id": "telegram",
-        "name": "Telegram",
-        "description": "Fast cloud-based messaging with file sharing",
-        "category": "Communication",
-        "targets": {
-            "arch": "telegram-desktop",
-            "opensuse": "telegram-desktop",
-            "nix": "telegram-desktop",
-            "flatpak": "org.telegram.desktop",
-            "snap": "telegram-desktop",
-            "homebrew": "--cask telegram"
-        },
-        "unavailableReason": "Recommended to use [Flatpak](https://flathub.org/apps/org.telegram.desktop) for the latest version. Debian 12 (Bookworm) has an older version (4.6.5) via `sudo apt install -y telegram-desktop`. Debian 13 (Trixie) removed the package entirely. Ubuntu 24.04/25.04 repos have outdated versions — use Flatpak or Snap for current releases. Fedora requires [RPM Fusion](https://rpmfusion.org/) repos.",
-        "icon": {
-            "type": "iconify",
-            "set": "simple-icons",
-            "name": "telegram",
-            "color": "#26A5E4"
-        }
-    },
-    {
-        "id": "signal",
-        "name": "Signal",
-        "description": "Secure end-to-end encrypted messaging app",
-        "category": "Communication",
-        "targets": {
-            "arch": "signal-desktop",
-            "opensuse": "signal-desktop",
-            "nix": "signal-desktop",
-            "flatpak": "org.signal.Signal",
-            "snap": "signal-desktop",
-            "homebrew": "--cask signal"
-        },
-        "unavailableReason": "Not in official repos. Use [Flatpak](https://flathub.org/en/apps/org.signal.Signal)/[Snap](https://snapcraft.io/signal-desktop) or follow instructions at [signal.org/download/linux](https://signal.org/download/linux/).",
-        "icon": {
-            "type": "iconify",
-            "set": "simple-icons",
-            "name": "signal",
-            "color": "#3A76F0"
-        }
-    },
-    {
-        "id": "slack",
-        "name": "Slack",
-        "description": "Team collaboration and business messaging",
-        "category": "Communication",
-        "targets": {
-            "arch": "slack-desktop",
-            "nix": "slack",
-            "flatpak": "com.slack.Slack",
-            "snap": "slack",
-            "homebrew": "--cask slack"
-        },
-        "unavailableReason": "Not in official repos. Use [Flatpak](https://flathub.org/en/apps/com.slack.Slack)/[Snap](https://snapcraft.io/slack) or download from [slack.com/downloads/linux](https://slack.com/downloads/linux).",
-        "icon": {
-            "type": "iconify",
-            "set": "simple-icons",
-            "name": "slack",
-            "color": "#4A154B"
-        }
-    },
-    {
-        "id": "zoom",
-        "name": "Zoom",
-        "description": "Popular video conferencing and meetings",
-        "category": "Communication",
-        "targets": {
-            "arch": "zoom",
-            "nix": "zoom-us",
-            "flatpak": "us.zoom.Zoom",
-            "snap": "zoom-client",
-            "homebrew": "--cask zoom"
-        },
-        "unavailableReason": "Not in official repos. Use [Flatpak](https://flathub.org/en/apps/us.zoom.Zoom)/[Snap](https://snapcraft.io/zoom-client) or download from [zoom.us/download/linux](https://zoom.us/download/linux).",
-        "icon": {
-            "type": "iconify",
-            "set": "simple-icons",
-            "name": "zoom",
-            "color": "#0B5CFF"
-        }
-    },
-    {
-        "id": "thunderbird",
-        "name": "Thunderbird",
-        "description": "Free email client by Mozilla with calendar",
-        "category": "Communication",
-        "targets": {
-            "ubuntu": "thunderbird",
-            "debian": "thunderbird",
-            "arch": "thunderbird",
-            "fedora": "thunderbird",
-            "opensuse": "MozillaThunderbird",
-            "nix": "thunderbird",
-            "flatpak": "org.mozilla.Thunderbird",
-            "snap": "thunderbird",
-            "homebrew": "--cask thunderbird"
-        },
-        "icon": {
-            "type": "iconify",
-            "set": "simple-icons",
-            "name": "thunderbird",
-            "color": "#0A84FF"
-        }
-    },
-    {
-        "id": "element",
-        "name": "Element",
-        "description": "Decentralized Matrix chat client with E2E encryption",
-        "category": "Communication",
-        "targets": {
-            "arch": "element-desktop",
-            "opensuse": "element-desktop",
-            "nix": "element-desktop",
-            "flatpak": "im.riot.Riot",
-            "snap": "element-desktop",
-            "homebrew": "--cask element"
-        },
-        "unavailableReason": "Not in official repos. Use [Flatpak](https://flathub.org/en/apps/im.riot.Riot)/[Snap](https://snapcraft.io/element-desktop) or follow instructions at [element.io/download#linux](https://element.io/en/download#linux).",
-        "icon": {
-            "type": "iconify",
-            "set": "simple-icons",
-            "name": "element",
-            "color": "#0DBD8B"
-        }
+    "unavailableReason": "Not in official repos. Install via [Flatpak](https://flathub.org/en/apps/com.discordapp.Discord) or download from [discord.com/download](https://discord.com/download).",
+    "icon": {
+      "type": "iconify",
+      "set": "simple-icons",
+      "name": "discord",
+      "color": "#5865F2"
     }
+  },
+  {
+    "id": "vesktop",
+    "name": "Vesktop",
+    "description": "Discord client with Vencord mods built-in",
+    "category": "Communication",
+    "targets": {
+      "arch": "vesktop-bin",
+      "nix": "vesktop",
+      "flatpak": "dev.vencord.Vesktop",
+      "homebrew": "--cask vesktop"
+    },
+    "unavailableReason": "Not available in official repos. Check it on [Flatpak](https://flathub.org/en/apps/dev.vencord.Vesktop) or Download from [vesktop.dev/install/linux](https://vesktop.dev/install/linux/).",
+    "icon": {
+      "type": "url",
+      "url": "https://avatars.githubusercontent.com/u/113042587?s=200&v=4"
+    }
+  },
+  {
+    "id": "telegram",
+    "name": "Telegram",
+    "description": "Fast cloud-based messaging with file sharing",
+    "category": "Communication",
+    "targets": {
+      "arch": "telegram-desktop",
+      "opensuse": "telegram-desktop",
+      "nix": "telegram-desktop",
+      "flatpak": "org.telegram.desktop",
+      "snap": "telegram-desktop",
+      "homebrew": "--cask telegram"
+    },
+    "unavailableReason": "Recommended to use [Flatpak](https://flathub.org/apps/org.telegram.desktop) for the latest version. Debian 12 (Bookworm) has an older version (4.6.5) via `sudo apt install -y telegram-desktop`. Debian 13 (Trixie) removed the package entirely. Ubuntu 24.04/25.04 repos have outdated versions — use Flatpak or Snap for current releases. Fedora requires [RPM Fusion](https://rpmfusion.org/) repos.",
+    "icon": {
+      "type": "iconify",
+      "set": "simple-icons",
+      "name": "telegram",
+      "color": "#26A5E4"
+    }
+  },
+  {
+    "id": "signal",
+    "name": "Signal",
+    "description": "Secure end-to-end encrypted messaging app",
+    "category": "Communication",
+    "targets": {
+      "arch": "signal-desktop",
+      "opensuse": "signal-desktop",
+      "nix": "signal-desktop",
+      "flatpak": "org.signal.Signal",
+      "snap": "signal-desktop",
+      "homebrew": "--cask signal"
+    },
+    "unavailableReason": "Not in official repos. Use [Flatpak](https://flathub.org/en/apps/org.signal.Signal)/[Snap](https://snapcraft.io/signal-desktop) or follow instructions at [signal.org/download/linux](https://signal.org/download/linux/).",
+    "icon": {
+      "type": "iconify",
+      "set": "simple-icons",
+      "name": "signal",
+      "color": "#3A76F0"
+    }
+  },
+  {
+    "id": "slack",
+    "name": "Slack",
+    "description": "Team collaboration and business messaging",
+    "category": "Communication",
+    "targets": {
+      "arch": "slack-desktop",
+      "nix": "slack",
+      "flatpak": "com.slack.Slack",
+      "snap": "slack",
+      "homebrew": "--cask slack"
+    },
+    "unavailableReason": "Not in official repos. Use [Flatpak](https://flathub.org/en/apps/com.slack.Slack)/[Snap](https://snapcraft.io/slack) or download from [slack.com/downloads/linux](https://slack.com/downloads/linux).",
+    "icon": {
+      "type": "iconify",
+      "set": "simple-icons",
+      "name": "slack",
+      "color": "#4A154B"
+    }
+  },
+  {
+    "id": "zoom",
+    "name": "Zoom",
+    "description": "Popular video conferencing and meetings",
+    "category": "Communication",
+    "targets": {
+      "arch": "zoom",
+      "nix": "zoom-us",
+      "flatpak": "us.zoom.Zoom",
+      "snap": "zoom-client",
+      "homebrew": "--cask zoom"
+    },
+    "unavailableReason": "Not in official repos. Use [Flatpak](https://flathub.org/en/apps/us.zoom.Zoom)/[Snap](https://snapcraft.io/zoom-client) or download from [zoom.us/download/linux](https://zoom.us/download/linux).",
+    "icon": {
+      "type": "iconify",
+      "set": "simple-icons",
+      "name": "zoom",
+      "color": "#0B5CFF"
+    }
+  },
+  {
+    "id": "thunderbird",
+    "name": "Thunderbird",
+    "description": "Free email client by Mozilla with calendar",
+    "category": "Communication",
+    "targets": {
+      "ubuntu": "thunderbird",
+      "debian": "thunderbird",
+      "arch": "thunderbird",
+      "fedora": "thunderbird",
+      "opensuse": "MozillaThunderbird",
+      "nix": "thunderbird",
+      "flatpak": "org.mozilla.Thunderbird",
+      "snap": "thunderbird",
+      "homebrew": "--cask thunderbird"
+    },
+    "icon": {
+      "type": "iconify",
+      "set": "simple-icons",
+      "name": "thunderbird",
+      "color": "#0A84FF"
+    }
+  },
+  {
+    "id": "element",
+    "name": "Element",
+    "description": "Decentralized Matrix chat client with E2E encryption",
+    "category": "Communication",
+    "targets": {
+      "arch": "element-desktop",
+      "opensuse": "element-desktop",
+      "nix": "element-desktop",
+      "flatpak": "im.riot.Riot",
+      "snap": "element-desktop",
+      "homebrew": "--cask element"
+    },
+    "unavailableReason": "Not in official repos. Use [Flatpak](https://flathub.org/en/apps/im.riot.Riot)/[Snap](https://snapcraft.io/element-desktop) or follow instructions at [element.io/download#linux](https://element.io/en/download#linux).",
+    "icon": {
+      "type": "iconify",
+      "set": "simple-icons",
+      "name": "element",
+      "color": "#0DBD8B"
+    }
+  },
+  {
+    "id": "neochat",
+    "name": "NeoChat",
+    "description": "Qt-based Matrix client by the KDE project",
+    "category": "Communication",
+    "targets": {
+      "ubuntu": "neochat",
+      "debian": "neochat",
+      "arch": "neochat",
+      "fedora": "neochat",
+      "opensuse": "neochat",
+      "nix": "neochat",
+      "flatpak": "org.kde.neochat",
+      "snap": "neochat"
+    },
+    "unavailableReason": "Not in official repos. Use [Flatpak](https://flathub.org/en/apps/org.kde.neochat) or [Snap](https://snapcraft.io/neochat).",
+    "icon": {
+      "type": "url",
+      "url": "https://apps.kde.org/app-icons/org.kde.neochat.svg"
+    }
+  }
 ]

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -271,5 +271,24 @@
       "type": "url",
       "url": "https://fluffychat.im/assets/info-logo.png"
     }
+  },
+  {
+    "id": "hexchat",
+    "name": "Hexchat",
+    "description": "Fully-featured IRC client",
+    "category": "Communication",
+    "targets": {
+      "ubuntu": "hexchat",
+      "debian": "hexchat",
+      "arch": "hexchat",
+      "fedora": "hexchat",
+      "opensuse": "hexchat",
+      "nix": "hexchat"
+    },
+    "unavailableReason": "Not in official repos. See [hexchat.github.io](https://hexchat.github.io/) for installation instructions.",
+    "icon": {
+      "type": "url",
+      "url": "https://upload.wikimedia.org/wikipedia/commons/4/4e/Hexchat_Logo.svg"
+    }
   }
 ]

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -309,5 +309,26 @@
       "type": "url",
       "url": "https://github.com/squidowl/halloy/blob/main/assets/logo.png"
     }
+  },
+  {
+    "id": "konversation",
+    "name": "Konversation",
+    "description": "IRC client by the KDE project",
+    "category": "Communication",
+    "targets": {
+      "ubuntu": "konversation",
+      "debian": "konversation",
+      "arch": "konversation",
+      "fedora": "konversation",
+      "opensuse": "konversation",
+      "nix": "konversation",
+      "flatpak": "org.kde.konversation",
+      "snap": "konversation"
+    },
+    "unavailableReason": "Not in official repos. Install using [Flatpak](https://flathub.org/en/apps/org.kde.konversation) or [Snap](https://snapcraft.io/konversation).",
+    "icon": {
+      "type": "url",
+      "url": "https://upload.wikimedia.org/wikipedia/commons/1/1a/Breezeicons-apps-48-konversation.svg"
+    }
   }
 ]

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -182,7 +182,7 @@
   {
     "id": "nheko",
     "name": "Nheko",
-    "description": "Matrix client with a familiar user interface",
+    "description": "High-performance native Matrix client built with C++/Qt, prioritizing low-latency synchronization.",
     "category": "Communication",
     "targets": {
       "ubuntu": "nheko",
@@ -203,14 +203,14 @@
   {
     "id": "cinny",
     "name": "Cinny",
-    "description": "Streamlined Matrix client",
+    "description": "A refined Matrix client focusing purely on user experience",
     "category": "Communication",
     "targets": {
       "arch": "cinny-desktop-bin",
       "nix": "cinny-desktop",
       "flatpak": "in.cinny.Cinny"
     },
-    "unavailableReason": "Not in official repos. Install using [Flatpak](https://flathub.org/en/apps/in.cinny.Cinny).",
+    "unavailableReason": "Not in most official repos. Install using [Flatpak](https://flathub.org/en/apps/in.cinny.Cinny) or visit [cinny.in](https://cinny.in/) for more info.",
     "icon": {
       "type": "url",
       "url": "https://cinny.in/assets/cinny.svg"
@@ -223,11 +223,11 @@
     "category": "Communication",
     "targets": {
       "arch": "fluffychat-bin",
-      "nix": "fluffychat-linux",
+      "nix": "fluffychat",
       "flatpak": "im.fluffychat.Fluffychat",
       "snap": "fluffychat"
     },
-    "unavailableReason": "Not available in official repos. Use [Flatpak](https://flathub.org/en/apps/im.fluffychat.Fluffychat) or Snap(https://snapcraft.io/fluffychat).",
+    "unavailableReason": "Not available in most official repos. Use [Flatpak](https://flathub.org/en/apps/im.fluffychat.Fluffychat) or Snap(https://snapcraft.io/fluffychat) or visit [fluffychat.im](https://fluffychat.im/) for more info.",
     "icon": {
       "type": "url",
       "url": "https://imgproxy.flathub.org/insecure/dpr:1/f:avif/q:100/rs:fit:128:128/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9pbS9mbHVmZnljaGF0L0ZsdWZmeWNoYXQvZWYxZjE1YWY0ZWYwZmYyMzdmNmE0NGNkNzdhNWRlOTYvaWNvbnMvMTI4eDEyOC9pbS5mbHVmZnljaGF0LkZsdWZmeWNoYXQucG5n"
@@ -246,7 +246,7 @@
       "snap": "halloy",
       "homebrew": "--cask halloy"
     },
-    "unavailableReason": "Not in official repos. Install it using [Flatpak](https://flathub.org/en/apps/org.squidowl.halloy) or [Snap](https://snapcraft.io/halloy).",
+    "unavailableReason": "Not in official repos. Install it using [Flatpak](https://flathub.org/en/apps/org.squidowl.halloy) or [Snap](https://snapcraft.io/halloy) or see [halloy.chat](https://halloy.chat/) for more info.",
     "icon": {
       "type": "url",
       "url": "https://halloy.chat/logo.png"
@@ -267,7 +267,7 @@
       "flatpak": "im.dino.Dino",
       "snap": "dino-tsugu"
     },
-    "unavailableReason": "Not available in official repos. Use [Flatpak](https://flathub.org/en/apps/im.dino.Dino) or [Snap](https://snapcraft.io/dino-tsugu).",
+    "unavailableReason": "Not available in official repos. Use [Flatpak](https://flathub.org/en/apps/im.dino.Dino) or [Snap](https://snapcraft.io/dino-tsugu) or visit [dino.im](https://dino.im/) for more info.",
     "icon": {
       "type": "url",
       "url": "https://dino.im/img/logo.svg"

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -350,5 +350,46 @@
       "type": "url",
       "url": "https://static.gnome.org/catalog/app-icon/scalable/org.gnome.Polari.svg"
     }
+  },
+  {
+    "id": "dino",
+    "name": "Dino",
+    "description": "GTK-based XMPP client for GNOME",
+    "category": "Communication",
+    "targets": {
+      "ubuntu": "dino-im",
+      "debian": "dino-im",
+      "arch": "dino",
+      "fedora": "dino",
+      "opensuse": "dino",
+      "nix": "dino",
+      "flatpak": "im.dino.Dino",
+      "snap": "dino-tsugu"
+    },
+    "unavailableReason": "Not available in official repos. Use [Flatpak](https://flathub.org/en/apps/im.dino.Dino) or [Snap](https://snapcraft.io/dino-tsugu).",
+    "icon": {
+      "type": "url",
+      "url": "https://dino.im/img/logo.svg"
+    }
+  },
+  {
+    "id": "kaidan",
+    "name": "Kaidan",
+    "description": "XMPP client by the KDE project",
+    "category": "Communication",
+    "targets": {
+      "ubuntu": "kaidan",
+      "debian": "kaidan",
+      "arch": "kaidan",
+      "fedora": "kaidan",
+      "opensuse": "kaidan",
+      "nix": "kaidan",
+      "flatpak": "im.kaidan.kaidan"
+    },
+    "unavailableReason": "Not available in official repos. Use [Flatpak](https://flathub.org/en/apps/im.kaidan.kaidan)",
+    "icon": {
+      "type": "url",
+      "url": "https://imgproxy.flathub.org/insecure/dpr:1/f:avif/q:100/rs:fit:128:128/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9pbS9rYWlkYW4va2FpZGFuL2Q3ZGY3NmJkYjRiMzgzMzYyZGEwOTVjNDA4N2YwMTYyL2ljb25zLzEyOHgxMjgvaW0ua2FpZGFuLmthaWRhbi5wbmc"
+    }
   }
 ]

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -238,5 +238,22 @@
       "type": "url",
       "url": "https://cinny.in/assets/cinny.svg"
     }
+  },
+  {
+    "id": "fluffy-chat",
+    "name": "Fluffy Chat",
+    "description": "Matrix client that uses Material Design",
+    "category": "Communication",
+    "targets": {
+      "arch": "fluffychat-bin",
+      "nix": "fluffychat-linux",
+      "flatpak": "im.fluffychat.Fluffychat",
+      "snap": "fluffychat"
+    },
+    "unavailableReason": "Not available in official repos. Use [Flatpak](https://flathub.org/en/apps/im.fluffychat.Fluffychat) or Snap(https://snapcraft.io/fluffychat).",
+    "icon": {
+      "type": "url",
+      "url": "https://fluffychat.im/assets/info-logo.png"
+    }
   }
 ]

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -44,10 +44,9 @@
     "category": "Communication",
     "targets": {
       "arch": "stoat-desktop-bin",
-      "nix": "stoat-desktop",
       "snap": "stoat-tsugu"
     },
-    "unavailableReason": "Not available in most official repos. Install it from [Snap](https://snapcraft.io/stoat-tsugu), or see install instructions at [stoat.chat](https://stoat.chat/download).",
+    "unavailableReason": "Still in early development and not yet available in most official repositories; it is recommended to build from source or see [stoat.chat](https://stoat.chat/download) for details.",
     "icon": {
       "type": "url",
       "url": "https://avatars.githubusercontent.com/u/234249415?s=200&v=4"

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -269,7 +269,7 @@
     "unavailableReason": "Not available in official repos. Use [Flatpak](https://flathub.org/en/apps/im.fluffychat.Fluffychat) or Snap(https://snapcraft.io/fluffychat).",
     "icon": {
       "type": "url",
-      "url": "https://fluffychat.im/assets/info-logo.png"
+      "url": "https://imgproxy.flathub.org/insecure/dpr:1/f:avif/q:100/rs:fit:128:128/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9pbS9mbHVmZnljaGF0L0ZsdWZmeWNoYXQvZWYxZjE1YWY0ZWYwZmYyMzdmNmE0NGNkNzdhNWRlOTYvaWNvbnMvMTI4eDEyOC9pbS5mbHVmZnljaGF0LkZsdWZmeWNoYXQucG5n"
     }
   },
   {
@@ -307,7 +307,7 @@
     "unavailableReason": "Not in official repos. Install it using [Flatpak](https://flathub.org/en/apps/org.squidowl.halloy) or [Snap](https://snapcraft.io/halloy).",
     "icon": {
       "type": "url",
-      "url": "https://github.com/squidowl/halloy/blob/main/assets/logo.png"
+      "url": "https://halloy.chat/logo.png"
     }
   },
   {

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -330,5 +330,25 @@
       "type": "url",
       "url": "https://upload.wikimedia.org/wikipedia/commons/1/1a/Breezeicons-apps-48-konversation.svg"
     }
+  },
+  {
+    "id": "polari",
+    "name": "Polari",
+    "description": "GTK-based IRC client for GNOME",
+    "category": "Communication",
+    "targets": {
+      "ubuntu": "polari",
+      "debian": "polari",
+      "arch": "polari",
+      "fedora": "polari",
+      "opensuse": "polari",
+      "nix": "polari",
+      "flatpak": "org.gnome.Polari"
+    },
+    "unavailableReason": "Not available in official repos. Use [Flatpak](https://flathub.org/en/apps/org.gnome.Polari).",
+    "icon": {
+      "type": "url",
+      "url": "https://static.gnome.org/catalog/app-icon/scalable/org.gnome.Polari.svg"
+    }
   }
 ]

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -180,45 +180,6 @@
     }
   },
   {
-    "id": "neochat",
-    "name": "NeoChat",
-    "description": "Qt-based Matrix client by the KDE project",
-    "category": "Communication",
-    "targets": {
-      "ubuntu": "neochat",
-      "debian": "neochat",
-      "arch": "neochat",
-      "fedora": "neochat",
-      "opensuse": "neochat",
-      "nix": "neochat",
-      "flatpak": "org.kde.neochat",
-      "snap": "neochat"
-    },
-    "unavailableReason": "Not in official repos. Use [Flatpak](https://flathub.org/en/apps/org.kde.neochat) or [Snap](https://snapcraft.io/neochat).",
-    "icon": {
-      "type": "url",
-      "url": "https://apps.kde.org/app-icons/org.kde.neochat.svg"
-    }
-  },
-  {
-    "id": "fractal",
-    "name": "Fractal",
-    "description": "Streamlined GTK-based Matrix client by the GNOME project",
-    "category": "Communication",
-    "targets": {
-      "arch": "fractal",
-      "fedora": "fractal",
-      "opensuse": "fractal",
-      "nix": "fractal",
-      "flatpak": "org.gnome.Fractal"
-    },
-    "unavailableReason": "Not in official repos. Install via [Flatpak](https://flathub.org/en/apps/org.gnome.Fractal). The Snap version is badly outdated.",
-    "icon": {
-      "type": "url",
-      "url": "https://upload.wikimedia.org/wikipedia/commons/b/b9/GNOME_Fractal_%282023%29.svg"
-    }
-  },
-  {
     "id": "nheko",
     "name": "Nheko",
     "description": "Matrix client with a familiar user interface",
@@ -273,25 +234,6 @@
     }
   },
   {
-    "id": "hexchat",
-    "name": "Hexchat",
-    "description": "Fully-featured IRC client",
-    "category": "Communication",
-    "targets": {
-      "ubuntu": "hexchat",
-      "debian": "hexchat",
-      "arch": "hexchat",
-      "fedora": "hexchat",
-      "opensuse": "hexchat",
-      "nix": "hexchat"
-    },
-    "unavailableReason": "Not in official repos. See [hexchat.github.io](https://hexchat.github.io/) for installation instructions.",
-    "icon": {
-      "type": "url",
-      "url": "https://upload.wikimedia.org/wikipedia/commons/4/4e/Hexchat_Logo.svg"
-    }
-  },
-  {
     "id": "halloy",
     "name": "Halloy",
     "description": "Slick IRC client written in Rust",
@@ -308,47 +250,6 @@
     "icon": {
       "type": "url",
       "url": "https://halloy.chat/logo.png"
-    }
-  },
-  {
-    "id": "konversation",
-    "name": "Konversation",
-    "description": "IRC client by the KDE project",
-    "category": "Communication",
-    "targets": {
-      "ubuntu": "konversation",
-      "debian": "konversation",
-      "arch": "konversation",
-      "fedora": "konversation",
-      "opensuse": "konversation",
-      "nix": "konversation",
-      "flatpak": "org.kde.konversation",
-      "snap": "konversation"
-    },
-    "unavailableReason": "Not in official repos. Install using [Flatpak](https://flathub.org/en/apps/org.kde.konversation) or [Snap](https://snapcraft.io/konversation).",
-    "icon": {
-      "type": "url",
-      "url": "https://upload.wikimedia.org/wikipedia/commons/1/1a/Breezeicons-apps-48-konversation.svg"
-    }
-  },
-  {
-    "id": "polari",
-    "name": "Polari",
-    "description": "GTK-based IRC client for GNOME",
-    "category": "Communication",
-    "targets": {
-      "ubuntu": "polari",
-      "debian": "polari",
-      "arch": "polari",
-      "fedora": "polari",
-      "opensuse": "polari",
-      "nix": "polari",
-      "flatpak": "org.gnome.Polari"
-    },
-    "unavailableReason": "Not available in official repos. Use [Flatpak](https://flathub.org/en/apps/org.gnome.Polari).",
-    "icon": {
-      "type": "url",
-      "url": "https://static.gnome.org/catalog/app-icon/scalable/org.gnome.Polari.svg"
     }
   },
   {
@@ -370,26 +271,6 @@
     "icon": {
       "type": "url",
       "url": "https://dino.im/img/logo.svg"
-    }
-  },
-  {
-    "id": "kaidan",
-    "name": "Kaidan",
-    "description": "XMPP client by the KDE project",
-    "category": "Communication",
-    "targets": {
-      "ubuntu": "kaidan",
-      "debian": "kaidan",
-      "arch": "kaidan",
-      "fedora": "kaidan",
-      "opensuse": "kaidan",
-      "nix": "kaidan",
-      "flatpak": "im.kaidan.kaidan"
-    },
-    "unavailableReason": "Not available in official repos. Use [Flatpak](https://flathub.org/en/apps/im.kaidan.kaidan)",
-    "icon": {
-      "type": "url",
-      "url": "https://imgproxy.flathub.org/insecure/dpr:1/f:avif/q:100/rs:fit:128:128/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9pbS9rYWlkYW4va2FpZGFuL2Q3ZGY3NmJkYjRiMzgzMzYyZGEwOTVjNDA4N2YwMTYyL2ljb25zLzEyOHgxMjgvaW0ua2FpZGFuLmthaWRhbi5wbmc"
     }
   }
 ]

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -38,6 +38,22 @@
     }
   },
   {
+    "id": "stoat",
+    "name": "Stoat",
+    "description": "Open-source Discord alternative",
+    "category": "Communication",
+    "targets": {
+      "arch": "stoat-desktop-bin",
+      "nix": "stoat-desktop",
+      "snap": "stoat-tsugu"
+    },
+    "unavailableReason": "Not available in most official repos. Install it from [Snap](https://snapcraft.io/stoat-tsugu), or see install instructions at [stoat.chat](https://stoat.chat/download).",
+    "icon": {
+      "type": "url",
+      "url": "https://avatars.githubusercontent.com/u/234249415?s=200&v=4"
+    }
+  },
+  {
     "id": "telegram",
     "name": "Telegram",
     "description": "Fast cloud-based messaging with file sharing",

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -222,5 +222,21 @@
       "type": "url",
       "url": "https://nheko-reborn.github.io/images/logo.png"
     }
+  },
+  {
+    "id": "cinny",
+    "name": "Cinny",
+    "description": "Streamlined Matrix client",
+    "category": "Communication",
+    "targets": {
+      "arch": "cinny-desktop-bin",
+      "nix": "cinny-desktop",
+      "flatpak": "in.cinny.Cinny"
+    },
+    "unavailableReason": "Not in official repos. Install using [Flatpak](https://flathub.org/en/apps/in.cinny.Cinny).",
+    "icon": {
+      "type": "url",
+      "url": "https://cinny.in/assets/cinny.svg"
+    }
   }
 ]

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -183,5 +183,23 @@
       "type": "url",
       "url": "https://apps.kde.org/app-icons/org.kde.neochat.svg"
     }
+  },
+  {
+    "id": "fractal",
+    "name": "Fractal",
+    "description": "Streamlined GTK-based Matrix client by the GNOME project",
+    "category": "Communication",
+    "targets": {
+      "arch": "fractal",
+      "fedora": "fractal",
+      "opensuse": "fractal",
+      "nix": "fractal",
+      "flatpak": "org.gnome.Fractal"
+    },
+    "unavailableReason": "Not in official repos. Install via [Flatpak](https://flathub.org/en/apps/org.gnome.Fractal). The Snap version is badly outdated.",
+    "icon": {
+      "type": "url",
+      "url": "https://upload.wikimedia.org/wikipedia/commons/b/b9/GNOME_Fractal_%282023%29.svg"
+    }
   }
 ]

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -201,5 +201,26 @@
       "type": "url",
       "url": "https://upload.wikimedia.org/wikipedia/commons/b/b9/GNOME_Fractal_%282023%29.svg"
     }
+  },
+  {
+    "id": "nheko",
+    "name": "Nheko",
+    "description": "Matrix client with a familiar user interface",
+    "category": "Communication",
+    "targets": {
+      "ubuntu": "nheko",
+      "debian": "nheko",
+      "arch": "nheko",
+      "fedora": "nheko",
+      "opensuse": "nheko",
+      "nix": "nheko",
+      "flatpak": "im.nheko.Nheko",
+      "homebrew": "--cask nheko"
+    },
+    "unavailableReason": "Not in official repos. Install via [Flatpak](https://flathub.org/en/apps/im.nheko.Nheko), or see [nheko-reborn.github.io](https://nheko-reborn.github.io/) for install instructions.",
+    "icon": {
+      "type": "url",
+      "url": "https://nheko-reborn.github.io/images/logo.png"
+    }
   }
 ]

--- a/src/lib/apps/communication.json
+++ b/src/lib/apps/communication.json
@@ -290,5 +290,24 @@
       "type": "url",
       "url": "https://upload.wikimedia.org/wikipedia/commons/4/4e/Hexchat_Logo.svg"
     }
+  },
+  {
+    "id": "halloy",
+    "name": "Halloy",
+    "description": "Slick IRC client written in Rust",
+    "category": "Communication",
+    "targets": {
+      "arch": "halloy",
+      "opensuse": "halloy",
+      "nix": "halloy",
+      "flatpak": "org.squidowl.halloy",
+      "snap": "halloy",
+      "homebrew": "--cask halloy"
+    },
+    "unavailableReason": "Not in official repos. Install it using [Flatpak](https://flathub.org/en/apps/org.squidowl.halloy) or [Snap](https://snapcraft.io/halloy).",
+    "icon": {
+      "type": "url",
+      "url": "https://github.com/squidowl/halloy/blob/main/assets/logo.png"
+    }
   }
 ]

--- a/src/lib/aur-packages.json
+++ b/src/lib/aur-packages.json
@@ -18,7 +18,6 @@
     "pycharm",
     "clion",
     "ivpn-ui",
-    "opera",
-    "hexchat"
+    "opera"
   ]
 }

--- a/src/lib/aur-packages.json
+++ b/src/lib/aur-packages.json
@@ -18,6 +18,7 @@
     "pycharm",
     "clion",
     "ivpn-ui",
-    "opera"
+    "opera",
+    "hexchat"
   ]
 }


### PR DESCRIPTION
## Summary

Added 11 new chat clients for various protocols.

## Changes
| App Name | Category | Sources |
|----------|----------|---------|
| Neochat  | Communication | apt, pacman, dnf, zypper, nix, flatpak, snap |
| Fractal | Communication | pacman, zypper, dnf, nix, flatpak |
| Nheko | Communication | apt, pacman, dnf, zypper, nix, flatpak, brew |
| Cinny | Communication | pacman, nix, flatpak |
| Fluffy Chat | Communication | pacman, snap, flatpak, nix |
| Hexchat | Communication | apt, dnf, pacman, zypper, nix |
| Halloy | Communication | pacman, zypper, nix, snap, flatpak, homebrew |
| Konversation | Communication | apt, pacman, dnf, zypper, nix, flatpak, snap |
| Polari | Communication | apt, pacman, dnf, zypper, nix, flatpak |
| Dino | Communication | apt, pacman, dnf, zypper, nix, flatpak, snap |
| Kaidan | Communication | apt, pacman, dnf, zypper, nix, flatpak |

## Verification
> Package names verified against official sources.

| Source | Link |
|--------|------|
| Repology | [Link](...) |
| Arch | [Link](...) |
| ... | ... |

## Testing
- [x] `npm run dev` working
- [x] `npm run build` passed
- [x] `npm run test` passed
- [x] `npm run lint` passed


## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
<img width="328" height="1014" alt="image" src="https://github.com/user-attachments/assets/7686d8db-3f2f-416e-859a-75f5b39c04af" />
